### PR TITLE
Read out timestamp from "timestamp.chk" instead of "timestamp.x"

### DIFF
--- a/plasmoid/contents/config/main.xml
+++ b/plasmoid/contents/config/main.xml
@@ -19,7 +19,7 @@
 			<default>50</default>
 		</entry>
 		<entry name="timestamp_command" type="String">
-			<default>cut -f 1 -d" " /usr/portage/metadata/timestamp.x</default>
+			<default>cat /usr/portage/metadata/timestamp.chk</default>
 		</entry>
 	</group>
 </kcfg>

--- a/plasmoid/contents/ui/Config.qml
+++ b/plasmoid/contents/ui/Config.qml
@@ -51,7 +51,7 @@ Item {
         }
 
         QtControls.Label {
-            text: i18n("Warnging threshold:")
+            text: i18n("Warning threshold:")
             Layout.alignment: Qt.AlignRight
         }
 

--- a/plasmoid/contents/ui/main.qml
+++ b/plasmoid/contents/ui/main.qml
@@ -48,7 +48,7 @@ Item {
             if (data["exit code"] == 0) {
                 portage_timestamp_raw_string = data["stdout"]
             } else {
-                portage_timestamp_raw_string = "no data"
+                portage_timestamp_raw_string = "0"
             }
             timestampChanged()
         }

--- a/plasmoid/contents/ui/main.qml
+++ b/plasmoid/contents/ui/main.qml
@@ -55,7 +55,7 @@ Item {
 
         function days_since_sync() {
             Date.prototype.getUnixTime = function() { return this.getTime()/1000|0 }
-            var portage_unix_timestamp = new Date(portage_timestamp_raw_string).getUnixTime()
+            var portage_unix_timestamp = new Date(executable.portage_timestamp_raw_string).getUnixTime()
 
             var now = Math.floor(Date.now() / 1000)
             var days = Math.floor((now - portage_unix_timestamp) / 86400)
@@ -73,7 +73,7 @@ Item {
             return "<b>Portage Sync Reminder</b>"
         }
         subText: {
-            return "<b>Portage sync timestamp</b>: " + new Date(executable.timestamp)
+            return "<b>Portage sync timestamp</b>: " + executable.portage_timestamp_raw_string
         }
     }
 

--- a/plasmoid/contents/ui/main.qml
+++ b/plasmoid/contents/ui/main.qml
@@ -37,7 +37,7 @@ Item {
         engine: "executable"
 
         // the data arrays
-        property int timestamp: 0
+        property string portage_timestamp_raw_string
 
         connectedSources: [
             plasmoid.configuration.timestamp_command
@@ -46,17 +46,20 @@ Item {
         // called when new data is available
         onNewData: {
             if (data["exit code"] == 0) {
-                timestamp = Number(data["stdout"])
+                portage_timestamp_raw_string = data["stdout"]
             } else {
-                timestamp = 0
+                portage_timestamp_raw_string = "no data"
             }
             timestampChanged()
         }
 
         function days_since_sync() {
+            Date.prototype.getUnixTime = function() { return this.getTime()/1000|0 }
+            var portage_unix_timestamp = new Date(portage_timestamp_raw_string).getUnixTime()
+
             var now = Math.floor(Date.now() / 1000)
-            var days = Math.floor((now - executable.timestamp) / 86400)
-            return days
+            var days = Math.floor((now - portage_unix_timestamp) / 86400)
+            return Number(days)
         }
 
         interval: plasmoid.configuration.update_interval * 1000 * 60

--- a/plasmoid/metadata.desktop
+++ b/plasmoid/metadata.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Encoding=UTF-8
-Name=Gentoo Portage Sync Remonder
+Name=Gentoo Portage Sync Reminder
 Comment=Tells you how many days passed since the last Portage sync
 Icon=system-software-update
 


### PR DESCRIPTION
Hi Michal,

I refactored the code, so the timestamp will be read out from the `timestamp.chk` which exists in portage's `rsync` and `git` repository. This string will be converted to `unix time` via `getUnixTime()` function; after that the value will be returned as a `Number()`.

Take a look and make it fancy please. :)

-Ramon